### PR TITLE
fix ciphers hash

### DIFF
--- a/ja4.lua
+++ b/ja4.lua
@@ -107,7 +107,7 @@ local function sni_is_set(txn)
 end
 
 local function cipher_count(txn)
-    local e = split_string(tostring(txn.c:be2dec(txn.f:ssl_fc_cipherlist_bin(1), '-', 2)), '-')
+    local e = split_string(txn.c:be2dec(txn.f:ssl_fc_cipherlist_bin(1), '-', 2), '-')
     local c = table_length(e)
     if (c > 99)
     then
@@ -118,7 +118,7 @@ local function cipher_count(txn)
 end
 
 local function extension_count(txn)
-    local e = split_string(tostring(txn.c:be2dec(txn.f:ssl_fc_extlist_bin(1), '-', 2)), '-')
+    local e = split_string(txn.c:be2dec(txn.f:ssl_fc_extlist_bin(1), '-', 2), '-')
     local c = table_length(e)
     if (c > 99)
     then
@@ -148,7 +148,7 @@ local function ciphers_sorted(txn)
 end
 
 local function extensions_sorted(txn)
-    local e1 = string.lower(tostring(txn.c:be2hex(txn.f:ssl_fc_extlist_bin(1), '-', 2)))
+    local e1 = string.lower(txn.c:be2hex(txn.f:ssl_fc_extlist_bin(1), '-', 2))
     local e2 = split_string(e1, '-')
 
     debug_var_str(txn, 'extensions_1', e1)

--- a/ja4.lua
+++ b/ja4.lua
@@ -139,7 +139,7 @@ local function alpn(txn)
 end
 
 local function ciphers_sorted(txn)
-    local c1 = string.lower(string.lower(tostring(txn.c:be2hex(txn.f:ssl_fc_cipherlist_bin(1), '-', 2))))
+    local c1 = string.lower(txn.c:be2hex(txn.f:ssl_fc_cipherlist_bin(1), '-', 2))
     local c2 = split_string(c1, '-')
     debug_var_str(txn, 'ciphers_1', c1)
     debug_var(txn, 'ciphers_2', c2)
@@ -195,7 +195,7 @@ function fingerprint_ja4(txn)
 
     local p7_sorted = ciphers_sorted(txn)
     local p7_pretty = table.concat(p7_sorted, ',')
-    local p7 = truncated_sha256(table.concat(p7_sorted, ''))
+    local p7 = truncated_sha256(table.concat(p7_sorted, ','))
 
     local p8_pretty = extensions_signature_merged(txn)
     local p8 = truncated_sha256(p8_pretty)

--- a/ja4.lua
+++ b/ja4.lua
@@ -195,7 +195,7 @@ function fingerprint_ja4(txn)
 
     local p7_sorted = ciphers_sorted(txn)
     local p7_pretty = table.concat(p7_sorted, ',')
-    local p7 = truncated_sha256(table.concat(p7_sorted, ','))
+    local p7 = truncated_sha256(p7_pretty)
 
     local p8_pretty = extensions_signature_merged(txn)
     local p8 = truncated_sha256(p8_pretty)


### PR DESCRIPTION
This change removes unnecessary string and lower conversions and fixes the table concatenation of the list of ciphers. The ciphers hash now matches the expected hash of the ja4 reference implementation.