### PR TITLE
Build haproxy from source in dev env

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,7 +1,52 @@
-ARG HAPROXY_VERSION=3.0
 FROM alpine:latest
+ENV HAPROXY_SRC_URL https://github.com/haproxy/haproxy/archive/refs/heads
 
-RUN apk --no-cache add curl python3 openssl
+LABEL MAINTAINER Rath Pascal <rath@oxl.at>
+
+# base source: https://github.com/haproxytech/haproxy-docker-alpine
+
+ARG HAPROXY_BRANCH
+
+ENV HAPROXY_BRANCH="${HAPROXY_BRANCH:-master}"
+
+LABEL DEVELOPMENT BUILD
+
+ENV HAPROXY_UID haproxy
+ENV HAPROXY_GID haproxy
+
+RUN test -n "$HAPROXY_BRANCH"
+
+RUN apk add --no-cache ca-certificates jemalloc && \
+    apk add --no-cache --virtual build-deps gcc libc-dev zip \
+    linux-headers lua5.4-dev make openssl openssl-dev pcre2-dev tar \
+    zlib-dev curl shadow jemalloc-dev && \
+    curl -sfSL "${HAPROXY_SRC_URL}/${HAPROXY_BRANCH}.zip" -o haproxy.tar.gz && \
+    groupadd "$HAPROXY_GID" && \
+    useradd -g "$HAPROXY_GID" "$HAPROXY_UID" && \
+    mkdir -p /tmp/haproxy && \
+    unzip haproxy.tar.gz -d /tmp/haproxy && \
+    mv /tmp/haproxy/haproxy-${HAPROXY_BRANCH}/* /tmp/haproxy && \
+    rm -f haproxy.tar.gz && \
+    make -C /tmp/haproxy -j"$(nproc)" TARGET=linux-musl CPU=generic USE_PCRE2=1 USE_PCRE2_JIT=1 \
+                            USE_TFO=1 USE_LINUX_TPROXY=1 USE_GETADDRINFO=1 \
+                            USE_LUA=1 LUA_LIB=/usr/lib/lua5.4 LUA_INC=/usr/include/lua5.4 \
+                            USE_PROMEX=1 USE_SLZ=1 \
+                            USE_OPENSSL=1 USE_PTHREAD_EMULATION=1 \
+                            USE_QUIC=1 USE_QUIC_OPENSSL_COMPAT=1 \
+                            ADDLIB=-ljemalloc \
+                            all && \
+    make -C /tmp/haproxy TARGET=linux2628 install-bin install-man && \
+    ln -s /usr/local/sbin/haproxy /usr/sbin/haproxy && \
+    mkdir -p /var/lib/haproxy && \
+    chown "$HAPROXY_UID:$HAPROXY_GID" /var/lib/haproxy && \
+    mkdir -p /usr/local/etc/haproxy && \
+    ln -s /usr/local/etc/haproxy /etc/haproxy && \
+    cp -R /tmp/haproxy/examples/errorfiles /usr/local/etc/haproxy/errors && \
+    rm -rf /tmp/haproxy && \
+    apk del build-deps && \
+    apk add --no-cache openssl zlib lua5.4-libs pcre2 curl python3 && \
+    rm -f /var/cache/apk/*
+
 ADD ../ja4db-to-map.py .
 RUN curl -s https://raw.githubusercontent.com/Egor-Skriptunoff/pure_lua_SHA/master/sha2.lua -o sha2.lua && \
     curl -s https://ja4db.com/api/read/ -o ja4+_db.json && \
@@ -11,10 +56,19 @@ RUN openssl req -x509 -newkey rsa:4096 -sha256 -nodes -subj "/CN=HAProxy JA4 Tes
     -out haproxy.crt.pem -days 30 && \
     cat haproxy.crt.pem haproxy.key.pem > haproxy.pem
 
-FROM haproxy:${HAPROXY_VERSION}
+FROM alpine:latest
+ENV HAPROXY_DOCKER_SRC_URL https://raw.githubusercontent.com/haproxytech/haproxy-docker-alpine/main/3.1/
+RUN apk add --no-cache openssl zlib lua5.4-libs pcre2 jemalloc
+ADD --chmod=755 "${HAPROXY_DOCKER_SRC_URL}/docker-entrypoint.sh" '/docker-entrypoint.sh'
+ADD --chmod=644 "${HAPROXY_DOCKER_SRC_URL}/haproxy.cfg" '/usr/local/etc/haproxy/haproxy.cfg'
+COPY --from=0 /usr/local/sbin/haproxy /usr/local/sbin/haproxy
 COPY --from=0 sha2.lua sha2.lua
 COPY --from=0 ja4.map /tmp/haproxy_ja4.map
 COPY --from=0 haproxy.pem /tmp/haproxy.pem
 ADD test/index.html /tmp/index.html
 
 EXPOSE 6969
+STOPSIGNAL SIGUSR1
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["haproxy", "-f", "/usr/local/etc/haproxy/haproxy.cfg"]

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
       context: ../
       dockerfile: test/Dockerfile
       args:
-        HAPROXY_VERSION: "3.0-alpine"
+        HAPROXY_BRANCH: "master"
     develop:
       watch:
       - path: ../


### PR DESCRIPTION
Since the `haproxy-ja4` lua plugin currently requires a HAProxy version which is only available in the master branch, the docker dev env now builds from source. Once the feature has been merged into a stable branch the dev env can be switched to a stable version throug the `HAPROXY_BRANCH` env var.

We could also think about switch back to a stable docker build once [d2fc1ab](https://github.com/haproxy/haproxy/commit/d2fc1ab66e49dffcf342c218a7eee345cac14989), [e8fecef](https://github.com/haproxy/haproxy/commit/e8fecef0ff9e4caaa9306fcdad7c6d45b1ab10ab), [ac5c715](https://github.com/haproxy/haproxy/commit/ac5c7158f97ab4e1758a1b1a5c7e5d0e1877a54e), [ce7fb66](https://github.com/haproxy/haproxy/commit/ce7fb6628e0023bbbf4ac2c70350f1c1069ce641) and [3c0a0f1](https://github.com/haproxy/haproxy/commit/3c0a0f1e1b8a8ebfad9ea6f10d0bc18e3c61033b) are meged.