### PR TITLE
fix alpn value

### DIFF
--- a/ja4.lua
+++ b/ja4.lua
@@ -103,13 +103,26 @@ local function bin_list_length(txn, func)
     return string.format('%02d', math.min(#items, 99))
 end
 
+local function is_alphanumeric(char)
+    return string.match(char, '%a') or string.match(char, '%d')
+end
+
 local function alpn(txn)
     local a = txn.f:ssl_fc_alpn()
+
     if (not a or a == '') then
         return '00'
-    else
-        return a
     end
+
+    local fc = string.sub(a, 1, 1)
+    local lc = string.sub(a, -1)
+
+    if (not is_alphanumeric(fc) or not is_alphanumeric(lc)) then
+        fc = string.format('%x', string.byte(fc)):sub(1, 1)
+        lc = string.format('%x', string.byte(lc, #lc)):sub(-1)
+    end
+
+    return fc .. lc
 end
 
 local function ciphers_sorted(txn)


### PR DESCRIPTION
In rare cases, the ALPN value may be 'http/1.1'. The current implementation returns the entire ALPN value, which results in the following issue:

[14/Sep/2024:03:35:58.419] https~ https/<NOSRV> -1/-1/-1/-1/0 -1 0 - - PR-- 25/24/0/0/0 0/0 "GET /.well-known/nodeinfo HTTP/1.1" 0/0000000000000000/0/0/0 example.com/TLSv1.3/TLS_CHACHA20_POLY1305_SHA256 __"t13d3613http/1.1_018971650b2c_5f333c0549e8"__ "t_13_d_36_13_http/1.1_002f,0033,0035,0039,003c,003d,0067,006b,009c,009d,009e,009f,00ff,1301,1302,1303,1304,c009,c00a,c013,c014,c023,c027,c02b,c02c,c02f,c030,c09c,c09d,c09e,c09f,c0ac,c0ad,cca8,cca9,ccaa_000a,000b,000d,0015,0016,0017,002b,002d,0031,0033,3374_0403,05"

This PR addresses the problem by extracting only the first letter and last letter from the ALPN value, as specified in the JA4 spec.


