### PR TITLE
set empty value of JA4_b and JA4_c

### DIFF
--- a/ja4.lua
+++ b/ja4.lua
@@ -146,7 +146,11 @@ local function extensions_signature_merged(txn)
 end
 
 local function truncated_sha256(txn, value)
-    return string.sub(string.lower(txn.c:hex(txn.c:digest(value, 'sha256'))), 1, 12)
+    if (#value == 0) then
+        return '000000000000'
+    else
+        return string.sub(string.lower(txn.c:hex(txn.c:digest(value, 'sha256'))), 1, 12)
+    end
 end
 
 function fingerprint_ja4(txn)


### PR DESCRIPTION
In accordance with the recent JA4 specification, if the sorted extensions/cipher list is empty, it should return '000000000000'. This PR resolves the issue by returning an empty value instead of the SHA-256 hash of an empty value, as outlined in the JA4 spec.